### PR TITLE
Add note on registration deadline

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,10 @@
               <td>Evaluation server open.</td>
             </tr>
             <tr>
+              <td style="width:20%;">24 March 2025</td>
+              <td>Deadline for team registration and adding of team members.</td>
+            </tr>
+            <tr>
               <td>31 Mar 2025</td>
               <td>Final submission deadline.</td>
             </tr>


### PR DESCRIPTION
Adding a note that we stop registrations one week before the final submission deadline.